### PR TITLE
Fix `Dockerfile` build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,6 @@ RUN npm ci
 
 RUN npm run build
 
-RUN npm run prestart:prod
-
 EXPOSE 3000
 
 CMD ["npm", "run", "start:prod"]


### PR DESCRIPTION
# Summary:

This pull request removes unnecesary command `npm run prestart:prod` from Dockerfile as node detects automatically when it runs `npm run start:prod`